### PR TITLE
Bump version requirement for asset installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "ext-xsl": "*",
-        "phpdocumentor/unified-asset-installer": "1.*",
+        "phpdocumentor/unified-asset-installer": "~1.1",
         "phpdocumentor/template-abstract": "1.*"
     }
 }


### PR DESCRIPTION
Once https://github.com/phpDocumentor/UnifiedAssetInstaller/pull/3 has been merged and a 1.1 release tagged this PR can be merged.

Consider tagging a `1.3` release as dependencies have changed
